### PR TITLE
Place ROP cache in user's homedir like "regular" cache

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -1048,7 +1048,7 @@ class ROP(object):
 
     def __get_cachefile_name(self, files):
         """Given an ELF or list of ELF objects, return a cache file for the set of files"""
-        cachedir = os.path.join(tempfile.gettempdir(), 'pwntools-rop-cache-%d.%d' % sys.version_info[:2])
+        cachedir = os.path.join(os.path.expanduser('~'), '.pwntools-rop-cache-%d.%d' % sys.version_info[:2])
         if not os.path.exists(cachedir):
             os.mkdir(cachedir)
 
@@ -1064,7 +1064,7 @@ class ROP(object):
     @staticmethod
     def clear_cache():
         """Clears the ROP gadget cache"""
-        cachedir = os.path.join(tempfile.gettempdir(), 'pwntools-rop-cache')
+        cachedir = os.path.join(os.path.expanduser('~'), '.pwntools-rop-cache-%d.%d' % sys.version_info[:2])
         shutil.rmtree(cachedir)
 
     def __cache_load(self, elf):


### PR DESCRIPTION
I don't have numbers on which would be more likely to be writable, a user's home directory or the OS's temp directory, but seems to me it'd make sense to try and write all caches to the same location.

Optimally this would be easily configurable to allow adjusting to different set-ups, obviously, but having things in the same place seems a decent start.

This is a change I find myself doing regularly to pwntools, when trying to init ROP fails due to not being able to write to /tmp, but don't know if it makes sense to the greater public.